### PR TITLE
Add Google Analytics tracking tag

### DIFF
--- a/themes/pelican-elegant/templates/base.html
+++ b/themes/pelican-elegant/templates/base.html
@@ -102,5 +102,15 @@
         </script>
         {% endblock script %}
         {% include '_includes/stat_counter.html' %}
+        <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-15096810-2', 'mergestories.com');
+  ga('send', 'pageview');
+
+        </script>
     </body>
 </html>


### PR DESCRIPTION
This will help us understand how people are using the site.

We should use http://openhatch.readthedocs.org/en/latest/community/web_analytics_team.html as our governing document, unless there is a reason to do otherwise.

Close #30
