### PR TITLE
Fix redirect after submitting a story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ include
 lib
 local
 output
+cache
 *~
 *.pyc

--- a/email_sending_backend/app.py
+++ b/email_sending_backend/app.py
@@ -107,7 +107,7 @@ def index():
         nice_data_dict = post_to_meaningful_data(d)
         msg = format_as_email(nice_data_dict)
         _send_email(msg)
-        return redirect('http://mergestories.com/pages/submitted.html')
+        return redirect('http://mergestories.com/submitted.html')
     else:
         return 'I think you wanted to POST.'
 


### PR DESCRIPTION
http://mergestories.com/pages/submitted.html is a broken version of the page where all the links point to `localhost:8000`, and it's not generated when I build the site locally.

http://mergestories.com/submitted.html is the working, nicely formatted version of the page.
